### PR TITLE
Doc nitpicks of URL and catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,13 +13,16 @@ metadata:
     - pytest
     - plugin
     - test-framework
-    - test-selection
+    - test-execution
     - testing
+    - public
   namespace: quality-community
   annotations:
+    servicenow.com/app-code: pytest-fixturecollection
     github.com/project-slug: RedHatQE/pytest-fixturecollection
     backstage.io/techdocs-ref: https://github.com/RedHatQE/pytest-fixturecollection/blob/main/README.rst
+    feedback/email-to: 'jyejare@redhat.com'
 spec:
-  type: plugin
+  type: library
   owner: group:redhat/redhat-qe
   lifecycle: production

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     maintainer='Jitendra Yejare',
     maintainer_email='jyejare@redhat.com',
     license='BSD-3',
-    url='https://github.com/SatelliteQE/pytest-fixturecollection',
+    url='https://github.com/RedhatQE/pytest-fixturecollection',
     description='A pytest plugin to collect tests based on fixtures being'
                 ' used by tests',
     long_description=read('README.rst'),


### PR DESCRIPTION
Doc-string Fixes and additions:

1. catalog- Now has more tags, email given, new annotation for service-now, type fixed
2. setup.py - Project URL is fixed.